### PR TITLE
fix(tmux): uncomment mouse config

### DIFF
--- a/tmux.sh
+++ b/tmux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# tmux set -g mouse on
+tmux set -g mouse on
 
 echo "✅ Initialized Tmux"


### PR DESCRIPTION
This PR uncomments the tmux mouse config. I accidentally left it commented out.